### PR TITLE
Remove -Weverything: it breaks the compilation on Apple Clang 9.1

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions(-D__STDC_FORMAT_MACROS)
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -Werror -Wall -Wextra -Weffc++ -Wswitch-default")
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough -Weverything")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall -Wextra -Weffc++ -Wswitch-default -Wfloat-equal -Wimplicit-fallthrough")
 endif()
 
 foreach (example ${EXAMPLES})


### PR DESCRIPTION
Hi,

using -Weverything to build the examples causes errors with the latest Apple Clang.
I removed it from the CMakeLists of the examples as done (in a more elaborate way) in the RapidJSON official repo.

Cheers,
Max